### PR TITLE
Remove redundant status check requirements from branch protection rules

### DIFF
--- a/.github/BRANCH_PROTECTION.md
+++ b/.github/BRANCH_PROTECTION.md
@@ -1,11 +1,9 @@
 # Git Workflow Configuration
 
 ## Branch Protection Rules
-# This should be configured in GitHub Settings > Branches
 
 ### Master Branch
 - Require pull request reviews before merging
-- Require status checks to pass before merging
 - Require branches to be up to date before merging
 - Require linear history
 - Do not allow force pushes
@@ -13,13 +11,10 @@
 
 ### QA Branch  
 - Require pull request reviews before merging
-- Require status checks to pass before merging
 - Require branches to be up to date before merging
-- Allow force pushes (for hotfixes if needed)
 
 ### Develop Branch
 - Require pull request reviews before merging
-- Require status checks to pass before merging
 
 ## Workflow Rules
 1. **Feature Development**: Create feature branches from `develop`


### PR DESCRIPTION
Eliminate unnecessary status check requirements for the master, QA, and develop branches to streamline the branch protection configuration.