### PR TITLE
fix: lambda error iam role

### DIFF
--- a/iac/bucket.tf
+++ b/iac/bucket.tf
@@ -2,15 +2,4 @@ resource "aws_s3_bucket" "notiapp_bucket" {
   bucket = "${var.bucket_name}-${var.environment}"
 }
 
-# resource "aws_s3_bucket_notification" "bucket_notification" {
-#   bucket = aws_s3_bucket.notiapp_bucket.id
 
-#   lambda_function {
-#     lambda_function_arn = aws_lambda_function.notiapp_processor.arn
-#     events              = ["s3:ObjectCreated:*"]
-#     filter_prefix       = "uploads/"
-#     filter_suffix       = ".json"
-#   }
-
-#   depends_on = [aws_lambda_permission.allow_bucket]
-# }

--- a/iac/lambda.tf
+++ b/iac/lambda.tf
@@ -11,6 +11,7 @@ data "aws_iam_policy_document" "assume_role" {
   }
 }
 
+#bug to solve!!
 resource "aws_iam_role" "iam_for_lambda" {
   name               = "${var.lambda_function_name}-role-${var.environment}"
   assume_role_policy = data.aws_iam_policy_document.assume_role.json
@@ -54,3 +55,19 @@ resource "aws_lambda_function" "notiapp_processor" {
 
   depends_on = [aws_iam_role.iam_for_lambda]
 }
+
+resource "aws_s3_bucket_notification" "bucket_notification" {
+  bucket = aws_s3_bucket.notiapp_bucket.id
+
+  lambda_function {
+    lambda_function_arn = aws_lambda_function.notiapp_processor.arn
+    events              = ["s3:ObjectCreated:*"]
+    filter_prefix       = "AWSLogs/"
+    filter_suffix       = ".log"
+  }
+  depends_on = [aws_iam_role.iam_for_lambda]
+
+}
+
+
+

--- a/iac/main.tf
+++ b/iac/main.tf
@@ -2,20 +2,22 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "6.12.0"
     }
   }
 }
 
 # Configure the AWS Provider
 provider "aws" {
-  region = "us-east-2"
-  profile = "jeancdev"
+  region  = "us-east-2"
+  #changue profile
+  profile = "default"
 
   default_tags {
     tags = {
       name = "NotiApp"
-      environment = terraform.workspace
+      #en enviroment se cambio debido a que ocurria error en mi maquina
+      environment = "dev"
     }
   }
 }


### PR DESCRIPTION
creating IAM Role (notiapp-processor-role-dev): operation error IAM: CreateRole, https response error StatusCode: 409, RequestID: 5473c749-78fd-4123-8af9-40a09ba9481b, EntityAlreadyExists: Role with name notiapp-processor-role-dev already exists.