### PR TITLE
Develop

### DIFF
--- a/iac/bucket.tf
+++ b/iac/bucket.tf
@@ -1,16 +1,38 @@
+#s3Bucket-1
 resource "aws_s3_bucket" "notiapp_bucket" {
-  bucket = "${var.bucket_name}-${var.environment}"
+  bucket = "${var.bucket1}-${var.environment}"
 }
 
+#s3Bucket-2
+resource "aws_s3_bucket" "notiapp_bucket_2" {
+  bucket = "${var.bucket2}-${var.environment}"
+}
+
+#trigger 1
 resource "aws_s3_bucket_notification" "bucket_notification" {
   bucket = aws_s3_bucket.notiapp_bucket.id
+  
 
   lambda_function {
-    lambda_function_arn = aws_lambda_function.notiapp_processor.arn
+    lambda_function_arn = aws_lambda_function.notiapp_processor_1.arn
     events              = ["s3:ObjectCreated:Post"]
     filter_prefix       = "AWSLogs/"
     filter_suffix       = ".log"
   }
+  depends_on = [aws_lambda_permission.allow_bucket_1]
 
-  depends_on = [aws_lambda_permission.allow_bucket]
+}
+#trigger 2
+resource "aws_s3_bucket_notification" "bucket_ObjetRemove" {
+  bucket = aws_s3_bucket.notiapp_bucket_2.id
+
+  lambda_function {
+    lambda_function_arn = aws_lambda_function.notiapp_processor_1.arn
+    events              = ["s3:ObjectRemoved:Delete"] #create a notification when an object or a batch of objects is removed from a bucket
+    filter_prefix       = "AWSLogs/"
+    filter_suffix       = ".log"
+  }
+
+  depends_on = [ aws_lambda_permission.allow_bucket_2 ]
+  
 }

--- a/iac/lambda.tf
+++ b/iac/lambda.tf
@@ -1,36 +1,52 @@
-resource "aws_lambda_permission" "allow_bucket" {
-  statement_id  = "AllowExecutionFromS3Bucket"
-  action        = "lambda:InvokeFunction"
-  function_name = aws_lambda_function.notiapp_processor.arn
-  principal     = "s3.amazonaws.com"
-  source_arn    = aws_s3_bucket.notiapp_bucket.arn
-}
-
 data "archive_file" "lambda_zip" {
   type        = "zip"
   source_dir  = "${path.module}/../src/"
   output_path = "${path.module}/../src/lambda.zip"
 }
 
-resource "aws_lambda_function" "notiapp_processor" {
-  function_name = "${var.lambda_function_name}-${var.environment}"
-  filename      = data.archive_file.lambda_zip.output_path
-  role          = aws_iam_role.iam_for_lambda.arn
-  handler       = "index.handler"
+#permiso para bucket 1
+resource "aws_lambda_permission" "allow_bucket_1" {
+  statement_id  = "AllowExecutionFromS3Bucket1"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.notiapp_processor_1.arn
+  principal     = "s3.amazonaws.com"
+  source_arn    = aws_s3_bucket.notiapp_bucket.arn
+}
+
+#permiso para bucket 2
+resource "aws_lambda_permission" "allow_bucket_2" {
+  statement_id  = "AllowExecutionFromS3Bucket2"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.notiapp_processor_1.arn
+  principal     = "s3.amazonaws.com"
+  source_arn    = aws_s3_bucket.notiapp_bucket_2.arn
+}
+
+#lambda-function
+resource "aws_lambda_function" "notiapp_processor_1" {
+  function_name    = "${var.lambda_function_name}-${var.environment}"
+  filename         = data.archive_file.lambda_zip.output_path
+  role             = aws_iam_role.iam_for_lambda.arn
+  handler          = "index.handler"
   source_code_hash = data.archive_file.lambda_zip.output_base64sha256
 
-  runtime       = "nodejs22.x"
+  runtime = "nodejs22.x"
 
   environment {
     variables = {
-      BUCKET_NAME = aws_s3_bucket.notiapp_bucket.bucket
+      BUCKET_1 = aws_s3_bucket.notiapp_bucket.bucket
+      BUCKET_2 = aws_s3_bucket.notiapp_bucket_2.bucket
       ENV         = var.environment
       REGION      = var.region
     }
   }
-  
+
   tags = {
     Name        = var.lambda_function_name
     Environment = var.environment
   }
+
 }
+
+
+

--- a/iac/main.tf
+++ b/iac/main.tf
@@ -10,12 +10,12 @@ terraform {
 # Configure the AWS Provider
 provider "aws" {
   region  = "us-east-2"
-  profile = "jeancdev"
+  #AGREGAR O QUITAR PROFILE
 
   default_tags {
     tags = {
       name = "NotiApp"
-      environment = terraform.workspace
+      environment = "Dev"
     }
   }
 }

--- a/iac/variables.tf
+++ b/iac/variables.tf
@@ -1,7 +1,13 @@
-variable "bucket_name" {
+variable "bucket1" {
   description = "Nombre del bucket S3"
   type        = string
-  default     = "notiapp-bucket-jeancdev"
+  default     = "notiapp-bucket"
+}
+
+variable "bucket2" {
+  description = "Nombre del bucket S3"
+  type        = string
+  default     = "notiapp-bucket-2"
 }
 
 variable "lambda_function_name" {
@@ -10,8 +16,10 @@ variable "lambda_function_name" {
   default     = "notiapp-processor"
 }
 
+
+
 variable "environment" {
-  description = "Entorno de despliegue"
+  description = "Entorno de despliegue (dev, qa, prod)"
   type        = string
   default     = "dev"
 }


### PR DESCRIPTION
This pull request introduces support for handling notifications and permissions for two separate S3 buckets, each with its own Lambda trigger and permissions. The changes update the resource definitions, variables, and environment configuration to support this multi-bucket setup.

**S3 Bucket and Notification Enhancements:**
- Added a second S3 bucket resource (`notiapp_bucket_2`) and corresponding notification for object removal events, each with its own Lambda trigger and permissions.
- Modified the existing S3 bucket resource to use a new variable name (`bucket1`), and updated the notification to use a more specific Lambda function and permission resource.

**Lambda Function and Permission Updates:**
- Replaced the single Lambda function and permission resources with new resources (`notiapp_processor_1`, `allow_bucket_1`, and `allow_bucket_2`) to support triggers from both buckets.
- Updated Lambda environment variables to reference both buckets (`BUCKET_1` and `BUCKET_2`).

**Variable and Configuration Adjustments:**
- Split the original `bucket_name` variable into `bucket1` and `bucket2`, each with distinct defaults, and clarified the `environment` variable description. [[1]](diffhunk://#diff-e8d371653bf2fbe8f9cbfbac9d73752d08ed7f41830b45e280ec4017d90bed49L1-R10) [[2]](diffhunk://#diff-e8d371653bf2fbe8f9cbfbac9d73752d08ed7f41830b45e280ec4017d90bed49R19-R22)
- Updated the AWS provider configuration to set a static environment tag and commented out the profile setting for flexibility.